### PR TITLE
SshAgent no longer forwarded on DP connections

### DIFF
--- a/BrainPortal/app/models/remote_resource.rb
+++ b/BrainPortal/app/models/remote_resource.rb
@@ -224,12 +224,17 @@ class RemoteResource < ApplicationRecord
   # for this RemoteResource. The method does not start it, if
   # it's created.
   def ssh_master
+    # SSH connect options are normally just the default ones,
+    # but an admin can override them in the meta data of the object.
+    # The SSH agent forwarding is mandatory however.
+    ssh_options = (self.meta[:ssh_config_options].presence || {})
+                  .dup.merge( :ForwardAgent => 'yes' )
     # category: we add the UNIX userid so as not to conflict
     # with any other user on the system when creating out socket in /tmp
     category = "#{self.class}_#{Process.uid}"
     uniq     = "#{self.id}"
     master   = SshMaster.find_or_create(self.ssh_control_user,self.ssh_control_host,self.ssh_control_port || 22,
-               :category => category, :uniq => uniq, :ssh_config_options => self.meta[:ssh_config_options])
+               :category => category, :uniq => uniq, :ssh_config_options => ssh_options )
     master
   end
 

--- a/BrainPortal/lib/ssh_master.rb
+++ b/BrainPortal/lib/ssh_master.rb
@@ -561,7 +561,7 @@ class SshMaster
   # itself but we do include the user and hostname.
   # A typical return value would be something like:
   #
-  #  "-port 1234 -A -o ConnectTimeout=10 -o ControlMaster=no -o ControlPath=/tmp/something user@host"
+  #  "-port 1234 -o ConnectTimeout=10 -o ControlMaster=no -o ControlPath=/tmp/something user@host"
   #
   # which allows you to add more options at the beginning
   # and the end of any ssh command being built. Note that
@@ -574,7 +574,6 @@ class SshMaster
     # Base options that are always present
     args_string  = ""
     args_string += " -p #{@port}" if @port != 22
-    args_string += " -A"
     args_string += " " + ssh_config_options_as_string()
 
     # When @nomaster is true, it means we're not even building


### PR DESCRIPTION
The SshMaster class was modified such that it no longer forwards the SSH Agent by default. The usual customers for the class are the Bourreaux and DataProviders; the bourreaux now request the agent explicitely and the DPs do not.